### PR TITLE
eclipse suggested parenthesis

### DIFF
--- a/ape_array.c
+++ b/ape_array.c
@@ -130,7 +130,7 @@ static ape_array_item_t *ape_array_add_s(ape_array_t *array, buffer *key)
 
     slot = (ape_array_item_t *)array->current;
 
-    if (slot == NULL || slot->pool.flags & APE_ARRAY_USED_SLOT) {
+    if (slot == NULL || (slot->pool.flags & APE_ARRAY_USED_SLOT)) {
         slot = (ape_array_item_t *)ape_grow_pool(array, 4);
     }
 
@@ -141,14 +141,14 @@ static ape_array_item_t *ape_array_add_s(ape_array_t *array, buffer *key)
     array->current = slot->pool.next;
 
     if (array->current == NULL ||
-        ((ape_array_item_t *)array->current)->pool.flags &
-        APE_ARRAY_USED_SLOT) {
+        (((ape_array_item_t *)array->current)->pool.flags &
+        APE_ARRAY_USED_SLOT)) {
 
         array->current = array->head;
 
         while (array->current != NULL &&
-                ((ape_array_item_t *)array->current)->pool.flags &
-                APE_ARRAY_USED_SLOT) {
+                (((ape_array_item_t *)array->current)->pool.flags &
+                APE_ARRAY_USED_SLOT)) {
             array->current = ((ape_array_item_t *)array->current)->pool.next;
         }
     }

--- a/ape_events_loop.c
+++ b/ape_events_loop.c
@@ -77,13 +77,13 @@ void events_loop(ape_global *ape)
                     }
 
                     if (APE_SOCKET(attach)->states.proto != APE_SOCKET_PT_UDP &&
-                        bitev & EVENT_READ &&
+                        (bitev & EVENT_READ) &&
                         ape_socket_read(APE_SOCKET(attach)) == -1) {
                         
                         /* ape_socket is planned to be release after the for block */
                         continue;
                     } else if (APE_SOCKET(attach)->states.proto ==
-                        APE_SOCKET_PT_UDP && bitev & EVENT_READ) {
+                        APE_SOCKET_PT_UDP && (bitev & EVENT_READ)) {
 
                         ape_socket_read_udp(APE_SOCKET(attach));
                     }

--- a/ape_pool.c
+++ b/ape_pool.c
@@ -163,7 +163,7 @@ void ape_destroy_pool(ape_pool_t *pool)
     }
     pool = tPool;
 
-    while (pool != NULL && pool->flags & APE_POOL_ALLOC) {
+    while (pool != NULL && (pool->flags & APE_POOL_ALLOC)) {
         tPool = pool->next;
         free(pool);
         pool = tPool;

--- a/ape_socket.c
+++ b/ape_socket.c
@@ -342,8 +342,8 @@ void APE_socket_shutdown(ape_socket *socket)
     if (socket->states.state != APE_SOCKET_ST_ONLINE) {
         return;
     }
-    if (socket->states.flags & APE_SOCKET_WOULD_BLOCK ||
-            socket->jobs.head->flags & APE_SOCKET_JOB_ACTIVE) {
+    if ((socket->states.flags & APE_SOCKET_WOULD_BLOCK) ||
+            (socket->jobs.head->flags & APE_SOCKET_JOB_ACTIVE)) {
         ape_socket_job_get_slot(socket, APE_SOCKET_JOB_SHUTDOWN);
         //printf("Shutdown pushed to queue\n");
         return;
@@ -474,8 +474,8 @@ int APE_sendfile(ape_socket *socket, const char *file)
         return 0;
     }
 
-    if (socket->states.flags & APE_SOCKET_WOULD_BLOCK ||
-            socket->jobs.head->flags & APE_SOCKET_JOB_ACTIVE) {
+    if ((socket->states.flags & APE_SOCKET_WOULD_BLOCK) ||
+            (socket->jobs.head->flags & APE_SOCKET_JOB_ACTIVE)) {
 
         socket->states.flags  |= APE_SOCKET_WOULD_BLOCK;
         job          = ape_socket_job_get_slot(socket, APE_SOCKET_JOB_SENDFILE);
@@ -548,8 +548,8 @@ int APE_socket_write(ape_socket *socket, void *data,
         return -1;
     }
 
-    if (socket->states.flags & APE_SOCKET_WOULD_BLOCK ||
-            socket->jobs.head->flags & APE_SOCKET_JOB_ACTIVE) {
+    if ((socket->states.flags & APE_SOCKET_WOULD_BLOCK) ||
+            (socket->jobs.head->flags & APE_SOCKET_JOB_ACTIVE)) {
         ape_socket_queue_data(socket, data, len, 0, data_type);
         //printf("Would block %d\n", len);
         return len;
@@ -672,7 +672,7 @@ int ape_socket_do_jobs(ape_socket *socket)
 #endif
     job = (ape_socket_jobs_t *)socket->jobs.head;
 
-    while(job != NULL && job->flags & APE_SOCKET_JOB_ACTIVE) {
+    while(job != NULL && (job->flags & APE_SOCKET_JOB_ACTIVE)) {
         switch(job->flags & ~(APE_POOL_ALL_FLAGS | APE_SOCKET_JOB_ACTIVE)) {
         case APE_SOCKET_JOB_WRITEV:
         {
@@ -1089,7 +1089,7 @@ static ape_socket_jobs_t *ape_socket_job_get_slot(ape_socket *socket, int type)
 
     /* If we request a write job we can push the data to the iov list */
     if ((type == APE_SOCKET_JOB_WRITEV &&
-            jobs->flags & APE_SOCKET_JOB_WRITEV) ||
+            (jobs->flags & APE_SOCKET_JOB_WRITEV)) ||
             !(jobs->flags & APE_SOCKET_JOB_ACTIVE)) {
 
         jobs->flags |= APE_SOCKET_JOB_ACTIVE | type;

--- a/ape_timers_next.c
+++ b/ape_timers_next.c
@@ -188,7 +188,7 @@ void clear_timer_by_id(ape_timers *timers, int identifier, int force)
     for (cur = timers->head; cur != NULL; cur = cur->next) {
         if (cur->identifier == identifier) {
             if (!(cur->flags & APE_TIMER_IS_PROTECTED) ||
-                (cur->flags & APE_TIMER_IS_PROTECTED && force)) {
+                ((cur->flags & APE_TIMER_IS_PROTECTED) && force)) {
                 
                 cur->flags |= APE_TIMER_IS_CLEARED;
             }


### PR DESCRIPTION
The eclipse IDE is a wonderfull tool to research and investigate foreign code, although it is not quite optimal for normal development. The codeanalysis feature of eclipse spits out a list of potential problems and make suggestions. One of the suggestions that eclipse made for libapenetwork was that parentheses should be used if bitwise operations take place.
