### PR TITLE
moved typedef before struct.

### DIFF
--- a/ape_array.h
+++ b/ape_array.h
@@ -39,12 +39,12 @@ typedef enum {
     APE_ARRAY_LIST
 } ape_array_index_e;
 
-struct _ape_array_item {
+typedef struct _ape_array_item {
     /* inherit from ape_pool_t (same first sizeof(ape_pool_t) bytes memory-print) */
     ape_pool_t pool;
     buffer *key;
     //buffer *val;
-} typedef ape_array_item_t;
+} ape_array_item_t;
 
 #ifdef __cplusplus
 extern "C" {

--- a/ape_socket.h
+++ b/ape_socket.h
@@ -194,13 +194,13 @@ struct _ape_socket {
 
 #define APE_SOCKET_PACKET_FREE (1 << 1)
 
-struct _ape_socket_packet {
+typedef struct _ape_socket_packet {
     /* inherit from ape_pool_t (same first sizeof(ape_pool_t) bytes memory-print) */
     ape_pool_t pool;
     size_t len;
     size_t offset;
     ape_socket_data_autorelease data_type;
-} typedef ape_socket_packet_t;
+} ape_socket_packet_t;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
With the default compile gcc compile flags a typedef may follow the struct declartion.
However, these two cases differ from the style that is used in the rest of the code.

This change creates a uniform style and let the user finetune the compile flags.
