### PR TITLE
moved initial declaration out of the for loop.

### DIFF
--- a/ape_buffer.c
+++ b/ape_buffer.c
@@ -354,7 +354,9 @@ void buffer_append_string_n(buffer *b, const char *string, size_t length)
 
 void buffer_camelify(buffer *b)
 {
-    for (unsigned char *pSource = b->data, pchar = '-'; *pSource; pSource++) {
+    unsigned char *pSource, pchar;
+
+    for (pSource = b->data, pchar = '-'; *pSource; pSource++) {
         if (pchar == '-') {
             *pSource = toupper(*pSource);
         }


### PR DESCRIPTION
The standard compile flags of gcc are  -std=gnu89. gnu89 is very strict on this. Moving this declaration out of the for loop gives a little bit more flexibility towards users.
