### PR TITLE
solved some compile warnings for -Wmissing-declarations

### DIFF
--- a/ape_dns.c
+++ b/ape_dns.c
@@ -119,7 +119,7 @@ static int params_free(void *arg)
     return 0;
 }
 
-void ares_gethostbyname_cb(void *arg, int status,
+static void ares_gethostbyname_cb(void *arg, int status,
         int timeout, struct hostent *host)
 {
     struct _ape_dns_cb_argv *params = arg;

--- a/ape_event_epoll.c
+++ b/ape_event_epoll.c
@@ -57,7 +57,7 @@ static int event_epoll_add(struct _fdevent *ev, int fd, int bitadd,
 
     return 1;
 }
-
+/*
 static int event_epoll_del(struct _fdevent *ev, int fd)
 {
     struct epoll_event kev;
@@ -72,6 +72,7 @@ static int event_epoll_del(struct _fdevent *ev, int fd)
 
     return 1;
 }
+*/
 
 static int event_epoll_poll(struct _fdevent *ev, int timeout_ms)
 {
@@ -111,7 +112,7 @@ static int event_epoll_revent(struct _fdevent *ev, int i)
 }
 
 
-int event_epoll_reload(struct _fdevent *ev)
+static int event_epoll_reload(struct _fdevent *ev)
 {
     int nfd;
     if ((nfd = dup(ev->epoll_fd)) != -1) {
@@ -134,7 +135,8 @@ int event_epoll_init(struct _fdevent *ev)
     ev->events = malloc(sizeof(struct epoll_event) * (ev->basemem));
 
     ev->add     = event_epoll_add;
-    ev->del     = /*event_epoll_del*/ NULL;
+    ev->del     = NULL;
+    /*ev->del     = event_epoll_del;*/
     ev->poll    = event_epoll_poll;
     ev->get_current_fd = event_epoll_get_fd;
     ev->setsize  = event_epoll_setsize;

--- a/ape_socket.h
+++ b/ape_socket.h
@@ -214,6 +214,7 @@ int APE_socket_connect(ape_socket *socket, uint16_t port,
         const char *remote_ip_host, uint16_t localport);
 int APE_socket_write(ape_socket *socket, void *data,
     size_t len, ape_socket_data_autorelease data_type);
+int APE_socket_writev(ape_socket *socket, const struct iovec *iov, int iovcnt);
 void APE_socket_shutdown(ape_socket *socket);
 void APE_socket_shutdown_now(ape_socket *socket);
 int APE_sendfile(ape_socket *socket, const char *file);


### PR DESCRIPTION
One function was used internally but not declared static.
One function was not defined in the header file although it was a public (APE_...)
One function was static but not used, because it was in a comment block.
Currently there is one more warning, but that will be solved by a8c152f4d59980ba2a738242719776520449414d.
