### PR TITLE
reduced the number of compiler warnings

### DIFF
--- a/ape_http_parser.c
+++ b/ape_http_parser.c
@@ -29,14 +29,6 @@
 #define MAX_CL 10485760
 #define MAX_RCODE 9999
 
-/* Todo : check for endieness + aligned */
-#define BYTES_GET(b) \
-    *(uint32_t *) b == ((' ' << 24) | ('T' << 16) | ('E' << 8) | 'G')
-
-#define BYTES_POST(b) \
-    *(uint32_t *) b == (('T' << 24) | ('S' << 16) | ('O' << 8) | 'P')
-
-
 typedef enum classes {
     C_NUL,  /* BAD CHAR */
     C_SPACE,/* space */

--- a/ape_http_parser.h
+++ b/ape_http_parser.h
@@ -22,6 +22,13 @@
 
 #include <stdint.h>
 
+/* Todo : check for endieness + aligned */
+#define BYTES_GET(b) \
+    *(uint32_t *) b == ((' ' << 24) | ('T' << 16) | ('E' << 8) | 'G')
+
+#define BYTES_POST(b) \
+    *(uint32_t *) b == (('T' << 24) | ('S' << 16) | ('O' << 8) | 'P')
+
 typedef enum type {
     HTTP_PARSE_ERROR,
     HTTP_METHOD,

--- a/ape_pool.c
+++ b/ape_pool.c
@@ -33,9 +33,9 @@ ape_pool_t *ape_new_pool(size_t size, size_t n)
     pool->prev = NULL;
 
     for (i = 0; i < n; i++) {
-        current            = ((char *)&pool[0])+(i*size);
+        current            = (ape_pool_t*)((char *)&pool[0])+(i*size);
         /* contiguous blocks */
-        current->next      = (i == n-1 ? NULL : ((char *)&pool[0])+((i+1)*size));
+        current->next      = (i == n-1 ? NULL : (ape_pool_t*)((char *)&pool[0])+((i+1)*size));
         current->ptr.data  = NULL;
         current->flags     = (i == 0 ? APE_POOL_ALLOC : 0);
         if (current->next) {
@@ -65,7 +65,7 @@ void ape_init_pool_list(ape_pool_list_t *list, size_t size, size_t n)
 
     list->head  = pool;
     list->current   = pool;
-    list->queue     = ((char *)&pool[0])+((n-1)*size);
+    list->queue     = (ape_pool_t*)((char *)&pool[0])+((n-1)*size);
     list->size = size;
 }
 

--- a/native_netlib.c
+++ b/native_netlib.c
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 
 
-#if _WIN32
+#ifdef _WIN32
 #include <WinSock2.h>
 #endif
 


### PR DESCRIPTION
Stricter compiler settingt that generate warnings often indicate that the code might be working differntly then expected.

With these modifications the code compiles without warnings with the following flags:
-Wall -Wextra -Winit-self -Werror -Wunreachable-code -Wdiv-by-zero -Wmultichar -Wdeprecated -Wmultichar -Wmissing-braces -Wmissing-noreturn -Waggregate-return -Winline -Wredundant-decls -Wwrite-strings -Wcast-align -Wshadow -Wformat-nonliteral -Wformat-security -Wformat=2 -Wendif-labels -Wundef -Wimport -Wunused-macros -Wpacked
// solved in other commits:
-Wno-unused-parameter -Wno-missing-declarations -Wno-old-style-declaration -Wno-switch-default -Wno-switch-enum
// to be solved by somebody who knows what he is doing :-)
-Wno-conversion -Wno-sign-compare -Wno-sign-conversion -Wno-strict-aliasing -Wno-pointer-arith

Please review the 3 casts of the pointers in ape_pool.c!
