### PR TITLE
added all enum cases and default in switch

### DIFF
--- a/ape_events.c
+++ b/ape_events.c
@@ -146,6 +146,9 @@ int events_init(ape_global *ape)
 		case EVENT_SELECT:
             return event_select_init(&ape->events);
 			break;
+        case EVENT_UNKNOWN:
+        case EVENT_DEVPOLL:
+        case EVENT_POLL:
         default:
             break;
     }

--- a/ape_events_loop.c
+++ b/ape_events_loop.c
@@ -132,6 +132,8 @@ void events_loop(ape_global *ape)
                 ((struct _ape_fd_delegate *)attach)->on_io(fd, bitev,
                     ((struct _ape_fd_delegate *)attach)->data, ape); /* punning */
                 break;
+            default:
+                break;
             }
         }
         nexttimeout = process_timers(&ape->timersng);

--- a/ape_hash.c
+++ b/ape_hash.c
@@ -449,6 +449,9 @@ unsigned int MurmurHash2 ( const void * key, int len, unsigned int seed )
     case 2: h ^= data[1] << 8;
     case 1: h ^= data[0];
             h *= m;
+            break;
+    default:
+            break;
     };
 
     // Do a few final mixes of the hash to ensure the last few

--- a/ape_socket.c
+++ b/ape_socket.c
@@ -98,6 +98,9 @@ __inline static void ape_socket_release_data(unsigned char *data, ape_socket_dat
         case APE_DATA_COPY:
             free(data);
             break;
+        case APE_DATA_STATIC:
+        case APE_DATA_GLOBAL_STATIC:
+        case APE_DATA_OWN:
         default:
             break;
     }


### PR DESCRIPTION
While using -Wswitch-default -Wswitch-enum compile flags with gcc, several warnings came up.
