### PR TITLE
Reduced a sign-compare warning.

### DIFF
--- a/ape_timers_next.c
+++ b/ape_timers_next.c
@@ -120,12 +120,12 @@ int process_timers(ape_timers *timers)
         }
 
         if ((start = mach_absolute_time()) >= cur->schedule-150000) {
-            uint64_t ret;
+            int ret;
             unsigned int duration;
             
             ret = cur->callback(cur->arg);
 
-            //printf("Timer returned %lld\n", ret);
+            //printf("Timer returned %d\n", ret);
 
             if (ret == -1) {
                 cur->schedule = start + cur->ticks_needs;


### PR DESCRIPTION
The callback signature returns an `int`. The variable `ret` is not used for calculation.
