### PR TITLE
Better validation and faster handling of pools.

### DIFF
--- a/ape_pool.c
+++ b/ape_pool.c
@@ -27,14 +27,16 @@ ape_pool_t *ape_new_pool(size_t size, const size_t n)
     const size_t stop = n - 1;
     ape_pool_t * pool, *current;
 
-     if (size == 0) {
+    if (size == 0) {
         size = sizeof(ape_pool_t);
     } else if ( n == 0 ) {
         return NULL;
     } else if (size < sizeof(ape_pool_t) ) {
         return NULL;
     }
-    
+    if (n == 0) {
+        return NULL;
+    }
     current = pool = malloc(size * n);
     pool->prev = NULL;
     i = 0;


### PR DESCRIPTION
During the setup of [unittest](https://github.com/nidium/libapenetwork/compare/master...verpeteren:a-unittest-proposal), this routine caused much confusion by me and valgrind.
This version is a little bit simpler, better to understand and a simple [benchmark](https://github.com/verpeteren/libapenetwork/commit/97aa65239f84ad83ca28c1acdd677ebd9de92e9c) showed that it is appox. 12 % faster.

As ape_pool is used in production, please test it thorgoughly.
