### PR TITLE
event_select compiles but does not work

### DIFF
--- a/ape_event_select.c
+++ b/ape_event_select.c
@@ -55,24 +55,22 @@ enum {
 
 typedef struct select_fdinfo_t
 {
-    void *ptr;
     int fd;
     char watchfor:8;
 } select_fdinfo_t;
 
-static int event_select_add(struct _fdevent *ev, int fd, int bitadd,
-        void *attach)
+static int event_select_add(struct _fdevent *ev,
+    ape_event_descriptor *evd, int bitadd)
 {
-    if (fd < 0 || fd > FD_SETSIZE) {
-        printf("cant add event %d\n", fd);
+    if (evd->fd < 0 || evd->fd > FD_SETSIZE) {
+        printf("cant add event %d\n", evd->fd);
         return -1;
     }
 
     select_fdinfo_t *fdinfo = malloc(sizeof(select_fdinfo_t));
-    fdinfo->fd = fd;
-    fdinfo->ptr = attach;
+    fdinfo->fd = evd->fd;
     fdinfo->watchfor = 0;
-  
+
     if (bitadd & EVENT_READ) {
         fdinfo->watchfor |= kWatchForRead_Event;
     }
@@ -81,11 +79,35 @@ static int event_select_add(struct _fdevent *ev, int fd, int bitadd,
         fdinfo->watchfor |= kWatchForWrite_Event;
     }
 
-    hashtbl_append64(ev->fdhash, fd, fdinfo);
+    hashtbl_append64(ev->fdhash, evd->fd, fdinfo);
 
-    printf("[++++] added %d\n", fd);
+    printf("[++++] added %d\n", evd->fd);
 
     return 1;
+}
+
+static int event_select_mod(struct _fdevent *ev,
+    ape_event_descriptor *evd, int bitadd)
+{
+    select_fdinfo_t * fdinfo;
+
+    fdinfo = hashtbl_seek64(ev->fdhash, evd->fd);
+    if (fdinfo == NULL ) {
+        return -1;
+    }
+    fdinfo->watchfor = 0;
+
+    if (bitadd & EVENT_READ) {
+        fdinfo->watchfor |= kWatchForRead_Event;
+    }
+
+    if (bitadd & EVENT_WRITE) {
+        fdinfo->watchfor |= kWatchForWrite_Event;
+    }
+
+    printf("[++++] modded %d\n", evd->fd);
+
+   return 1;
 }
 
 static int event_select_del(struct _fdevent *ev, int fd)
@@ -184,9 +206,9 @@ static int event_select_poll(struct _fdevent *ev, int timeout_ms)
     return i;
 }
 
-static void *event_select_get_fd(struct _fdevent *ev, int i)
+static ape_event_descriptor *event_select_get_evd(struct _fdevent *ev, int i)
 {
-    return ev->events[i]->ptr;
+    return (ape_event_descriptor *)ev->events[i];
 }
 
 static int event_select_revent(struct _fdevent *ev, int i)
@@ -246,12 +268,13 @@ int event_select_init(struct _fdevent *ev)
     ev->add               = event_select_add;
     ev->del               = event_select_del;
     ev->poll              = event_select_poll;
-    ev->get_current_fd    = event_select_get_fd;
+    ev->get_current_evd   = event_select_get_evd;
+    ev->setsize           = event_select_setsize;
     ev->revent            = event_select_revent;
     ev->reload            = event_select_reload;
-    ev->setsize           = event_select_setsize;
+    ev->mod               = event_select_mod;
 
-    printf("select() started with %i slots\n", ev->basemem);
+    printf("Event loop started using select() with %i slots\n", ev->basemem);
 
     return 1;
 }


### PR DESCRIPTION
As discussed in [this issue](https://github.com/nidium/libapenetwork/issues/43), this pull request makes the select_handler compile again
But there is probably still a lot of 'technical dept' that needs to be paid to get the select handler uptodate with the latest changes.
