### PR TITLE
Improving includes

### DIFF
--- a/src/ape_array.c
+++ b/src/ape_array.c
@@ -5,8 +5,9 @@
 */
 
 #include "ape_array.h"
-#include <string.h>
 
+#include <string.h>
+#include <strings.h>
 
 static void ape_array_clean_cb(ape_pool_t *item, void *ctx);
 

--- a/src/ape_array.h
+++ b/src/ape_array.h
@@ -11,7 +11,9 @@
 #include "ape_buffer.h"
 
 #ifdef _WIN32
-#include "port/windows.h"
+  #include "port/windows.h"
+#else
+  #include "port/POSIX.h"
 #endif
 
 typedef ape_pool_list_t ape_array_t;

--- a/src/ape_base64.c
+++ b/src/ape_base64.c
@@ -4,10 +4,10 @@
    that can be found in the LICENSE file.
 */
 
+#include "ape_base64.h"
+
 #include <stdint.h>
 #include <stdlib.h>
-
-#include "ape_base64.h"
 
 // "3f"
 static uint8_t map2[] = {

--- a/src/ape_blowfish.c
+++ b/src/ape_blowfish.c
@@ -22,7 +22,7 @@
  */
 
 #include "ape_blowfish.h"
-#include <stdlib.h>
+
 #include <string.h>
 
 static const uint32_t orig_p[APE_BF_ROUNDS + 2] = {

--- a/src/ape_buffer.c
+++ b/src/ape_buffer.c
@@ -8,12 +8,12 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 #include <ctype.h>
+#include <unistd.h>
+
 #include "ape_common.h"
 
 #define ZBUF_BUFSIZE 1024
-
 
 #if APE_USE_ZLIB
 struct gztrailer {

--- a/src/ape_buffer.h
+++ b/src/ape_buffer.h
@@ -8,11 +8,11 @@
 #define __APE_BUFFER_H_
 
 #include <stdlib.h>
-#include <sys/types.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 #ifndef _WIN32
-#define APE_USE_ZLIB 1
+  #define APE_USE_ZLIB 1
 #include <zlib.h>
 
 typedef struct {

--- a/src/ape_common.h
+++ b/src/ape_common.h
@@ -10,23 +10,23 @@
 #define _APE_COMMON_H_
 
 #ifndef USE_SPECIFIC_HANDLER
-#ifdef __linux__
-#define USE_EPOLL_HANDLER
-#elif defined(__APPLE__)
-#define USE_KQUEUE_HANDLER
-#elif defined(_MSC_VER)
-#define USE_SELECT_HANDLER
-#define __WIN32
-#else
-#error "No suitable IO handler found"
-#endif
+  #ifdef __linux__
+    #define USE_EPOLL_HANDLER
+  #elif defined(__APPLE__)
+    #define USE_KQUEUE_HANDLER
+  #elif defined(_MSC_VER)
+    #define USE_SELECT_HANDLER
+    #define __WIN32
+  #else
+    #error "No suitable IO handler found"
+  #endif
 #endif
 
 #ifdef _WIN32
-#include "port/windows.h"
-#include <winsock2.h>
+  #include "port/windows.h"
+  #include <winsock2.h>
 #else
-#include "port/POSIX.h"
+  #include "port/POSIX.h"
 #endif
 
 #ifndef APE_TIMER_RESOLUTION

--- a/src/ape_dns.c
+++ b/src/ape_dns.c
@@ -4,27 +4,21 @@
    that can be found in the LICENSE file.
 */
 
-#ifdef _WIN32
-#include <ares.h>
-#include <io.h>
-#include <winsock2.h>
-#else
-#include "ares.h"
-#include <netdb.h>
-#include <unistd.h>
-#include <arpa/inet.h>
-#endif
+#include "ape_dns.h"
 
 #include <stdlib.h>
-#include "ape_common.h"
-#include "ape_dns.h"
-#include "ape_events.h"
-
-#include <stdio.h>
-
 #include <fcntl.h>
+#include <unistd.h>
 
-/* gcc *.c -I../deps/ ../deps/c-ares/.libs/libcares.a -lrt */
+#ifdef _WIN32
+  #include <io.h>
+  #include <winsock2.h>
+#else
+  #include <netdb.h>
+  #include <unistd.h>
+  #include <arpa/inet.h>
+  #include <netinet/in.h>
+#endif
 
 #ifdef FIONBIO
 static __inline int setnonblocking(int fd)

--- a/src/ape_dns.h
+++ b/src/ape_dns.h
@@ -9,6 +9,8 @@
 
 #define _HAS_ARES_SUPPORT
 
+#include <ares.h>
+
 #include "ape_common.h"
 
 #ifdef __cplusplus

--- a/src/ape_event_epoll.c
+++ b/src/ape_event_epoll.c
@@ -5,18 +5,13 @@
 */
 
 #include "ape_common.h"
-#include "ape_events.h"
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-#include <time.h>
-#include <string.h>
+
 #include <stdlib.h>
-#include <stdio.h>
+#include <unistd.h>
 
-
-#include "ape_socket.h"
+#ifndef _WIN32
+  #include <sys/time.h>
+#endif
 
 #ifdef USE_EPOLL_HANDLER
 

--- a/src/ape_event_kqueue.c
+++ b/src/ape_event_kqueue.c
@@ -5,17 +5,14 @@
 */
 
 #include "ape_common.h"
-#include "ape_events.h"
-#include "ape_socket.h"
-#ifndef __WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-#include <time.h>
 
 #include <string.h>
 #include <stdlib.h>
-#include <stdio.h>
+#include <unistd.h>
+
+#ifndef _WIN32
+  #include <sys/time.h>
+#endif
 
 #ifdef USE_KQUEUE_HANDLER
 

--- a/src/ape_event_select.c
+++ b/src/ape_event_select.c
@@ -4,21 +4,16 @@
    that can be found in the LICENSE file.
 */
 
-#include "ape_common.h"
-#include "ape_events.h"
-#ifndef __WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#else
-#include "port\windows.h"
-#endif
-#include <time.h>
 #include <string.h>
 #include <stdlib.h>
-#include <stdio.h>
+#include <unistd.h>
+#include <sys/time.h>
 
-
-#include "ape_socket.h"
+#ifndef _WIN32
+  #include "port/POSIX.h"
+#else
+  #include "port\windows.h"
+#endif
 
 #ifdef USE_SELECT_HANDLER
 

--- a/src/ape_events.c
+++ b/src/ape_events.c
@@ -5,11 +5,8 @@
 */
 
 #include "ape_common.h"
-#include "ape_events.h"
-#include "ape_socket.h"
 
 #include <stdlib.h>
-#include <stdio.h>
 
 #define APE_DEFAULT_EVENTS_SIZE 32
 

--- a/src/ape_events.h
+++ b/src/ape_events.h
@@ -11,12 +11,9 @@
 
 #ifdef USE_KQUEUE_HANDLER
   #include <sys/event.h>
-#endif
-
-#ifdef USE_EPOLL_HANDLER
+#elif defined USE_EPOLL_HANDLER
   #include <sys/epoll.h>
-#endif
-#ifdef USE_SELECT_HANDLER
+#elif defined USE_SELECT_HANDLER
   #ifndef _WIN32
     #include <sys/select.h>
   #endif

--- a/src/ape_events.h
+++ b/src/ape_events.h
@@ -10,18 +10,19 @@
 #include "ape_common.h"
 
 #ifdef USE_KQUEUE_HANDLER
-#include <sys/event.h>
+  #include <sys/event.h>
 #endif
+
 #ifdef USE_EPOLL_HANDLER
-#include <sys/epoll.h>
+  #include <sys/epoll.h>
 #endif
 #ifdef USE_SELECT_HANDLER
-#ifndef _WIN32
-#include <sys/select.h>
-#endif
-#ifndef FD_SETSIZE
-#error "FD_SETSIZE NOT DEFINED"
-#endif
+  #ifndef _WIN32
+    #include <sys/select.h>
+  #endif
+  #ifndef FD_SETSIZE
+    #error "FD_SETSIZE NOT DEFINED"
+  #endif
 #endif
 
 #include "ape_hash.h"

--- a/src/ape_events_loop.c
+++ b/src/ape_events_loop.c
@@ -4,17 +4,13 @@
    that can be found in the LICENSE file.
 */
 
-#include "ape_common.h"
-#include "ape_events.h"
-#include "ape_socket.h"
-#include "ape_timers_next.h"
 #include "ape_events_loop.h"
 
-#ifndef __WIN32
-#include <sys/time.h>
+#ifndef _WIN32
+  #include <sys/time.h>
 #endif
-#include <stdio.h>
-#include <stddef.h>
+
+#include "ape_socket.h"
 
 extern int ape_running;
 

--- a/src/ape_hash.c
+++ b/src/ape_hash.c
@@ -4,23 +4,19 @@
    that can be found in the LICENSE file.
 */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#ifndef _WIN32
-#include <unistd.h>
-#else
-#include "port/windows.h"
-#endif
-
 #include "ape_hash.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+#include <sys/time.h>
 
-#define HACH_TABLE_MAX 8209
+#ifndef _WIN32
+  #include "port/POSIX.h"
+#else
+  #include "port/windows.h"
+#endif
 
 extern unsigned long _ape_seed;
 

--- a/src/ape_hash.h
+++ b/src/ape_hash.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 
+#define HACH_TABLE_MAX 8209
 
 typedef struct _ape_htable_item ape_htable_item_t;
 

--- a/src/ape_log.c
+++ b/src/ape_log.c
@@ -4,11 +4,11 @@
    that can be found in the LICENSE file.
 */
 
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "ape_log.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
 
 void APE_setlogger(ape_logger_t *logger, const ape_log_lvl_t lvl,
     const ape_log_init_callback_t init, const ape_log_log_callback_t log,
@@ -60,7 +60,7 @@ int APE_logf(const ape_logger_t *logger, const ape_log_lvl_t lvl,
     logged = APE_log(logger, lvl, tag, buff);
 
     free(buff);
-    
+
     return logged;
 }
 

--- a/src/ape_netlib.c
+++ b/src/ape_netlib.c
@@ -5,21 +5,20 @@
 */
 
 #include "ape_netlib.h"
-#include "ape_common.h"
-#include "ape_dns.h"
-#include "ape_ssl.h"
 
 #include <stdlib.h>
 #include <signal.h>
-#include <time.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <ares.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
+  #include <WinSock2.h>
 #endif
+
+#include "ape_dns.h"
 
 int ape_running = 1;
 

--- a/src/ape_netlib.h
+++ b/src/ape_netlib.h
@@ -8,6 +8,7 @@
 #define _APE_NETLIB_H_
 
 #include "ape_common.h"
+
 #include "ape_socket.h"
 #include "ape_events_loop.h"
 #include "ape_timers_next.h"

--- a/src/ape_pool.c
+++ b/src/ape_pool.c
@@ -5,8 +5,8 @@
 */
 
 #include "ape_pool.h"
+
 #include <stdlib.h>
-#include <stdio.h>
 
 ape_pool_t *ape_new_pool(size_t size, size_t n)
 {

--- a/src/ape_sha1.c
+++ b/src/ape_sha1.c
@@ -17,10 +17,10 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  *  MA  02110-1301  USA
  */
+#include "ape_sha1.h"
+
 #include <string.h>
 #include <stdio.h>
-
-#include "ape_sha1.h"
 /*
  *  The SHA-1 standard was published by NIST in 1993.
  *

--- a/src/ape_socket.c
+++ b/src/ape_socket.c
@@ -5,36 +5,36 @@
 */
 
 #include "ape_socket.h"
-#include "ape_dns.h"
-#include "ape_timers_next.h"
-#include "ape_ssl.h"
-#include <stdint.h>
-#include <stdio.h>
-#ifndef _WIN32
-#include <sys/time.h>
+
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/uio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/time.h>
+
 #include <openssl/err.h>
+
+#ifndef _WIN32
 #else
-#include <io.h>
-#include <malloc.h>
+  #include <io.h>
+  #include <malloc.h>
 #endif
-#include <fcntl.h>
-#include <time.h>
-#include <errno.h>
-#include <stdlib.h>
 
 #ifdef _MSC_VER
-#include <ares.h>
+  #include "port\windows.h"
 #else
-#include "ares.h"
+  #include "port/POSIX.h"
 #endif
 
 #ifdef __linux__
-#include <sys/sendfile.h>
+  #include <sys/sendfile.h>
 #endif
-#include <limits.h>
-#include <string.h>
 
 #define APE_LZ4_BLOCK_SIZE (1024 * 8)
 #define APE_LZ4_BLOCK_COMP_SIZE APE_LZ4_COMPRESSBOUND(APE_LZ4_BLOCK_SIZE)

--- a/src/ape_socket.h
+++ b/src/ape_socket.h
@@ -8,22 +8,32 @@
 #define __APE_SOCKET_H
 
 #include "ape_common.h"
+
 #include "ape_buffer.h"
 #include "ape_pool.h"
 #include "ape_lz4.h"
+#include "ape_dns.h"
 
 #ifdef _WIN32
-#define ioctl ioctlsocket
-#define hstrerror(x) ""
-#include "port/windows.h"
+  //#include <winsock2.h>
+  //#pragma comment(lib, "ws2_32.lib")
+  #if 0
+    #define ECONNRESET WSAECONNRESET
+    #define EINPROGRESS WSAEINPROGRESS
+    #define EALREADY WSAEALREADY
+    #define ECONNABORTED WSAECONNABORTED
+  #endif
+  #define ioctl ioctlsocket
+  #define hstrerror(x) ""
 #else
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/un.h>
-#include <arpa/inet.h>
-#include <netdb.h>
+  #include <sys/socket.h>
+  #include <sys/ioctl.h>
+  #include <sys/un.h>
+  #include <netinet/in.h>
+  #include <netinet/tcp.h>
+  #include <arpa/inet.h>
+
+  #include <netdb.h>
 #endif
 
 #define APE_SOCKET_BACKLOG 511

--- a/src/ape_ssl.c
+++ b/src/ape_ssl.c
@@ -2,6 +2,9 @@
 #include "ape_log.h"
 
 #if _HAVE_SSL_SUPPORT
+#include <stdio.h>
+#include <stdlib.h>
+
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/conf.h>

--- a/src/ape_timers_next.c
+++ b/src/ape_timers_next.c
@@ -5,9 +5,11 @@
 */
 
 #include "ape_timers_next.h"
-#include "ape_common.h"
+
 #include <stdlib.h>
-#include <stdio.h>
+#include <time.h>
+
+#include "ape_common.h"
 
 static void process_async(ape_timers *timers);
 static void del_async_all(ape_timers *timers);

--- a/src/ape_websocket.c
+++ b/src/ape_websocket.c
@@ -5,17 +5,16 @@
 */
 
 #include "ape_websocket.h"
-#include "ape_sha1.h"
-#include "ape_base64.h"
-
-#include "ape_socket.h"
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#ifndef _WIN32
+#include <unistd.h>
 #include <arpa/inet.h>
-#endif
+#include <netinet/in.h>
+
+#include "ape_sha1.h"
+#include "ape_base64.h"
 
 #define WS_GUID "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 


### PR DESCRIPTION
The include headers have been reorganized with the aid of the 'deheader' tool.
This PR is replaces an [older PR](https://github.com/nidium/libapenetwork/pull/42) that was outdated.

Please note that the various '__WIN32', '_WIN32', '_MSC_VER' might need a detailed review later.