### PR TITLE
(int) APE_socket_port(socket) implementation

### DIFF
--- a/src/ape_socket.c
+++ b/src/ape_socket.c
@@ -906,16 +906,14 @@ int APE_socket_write(ape_socket *socket, void *data, size_t len,
     return 0;
 }
 
-int APE_socket_port(ape_socket *socket)
+uint16_t APE_socket_port(ape_socket *socket)
 {
     if (!socket) {
-        return -1;
+        return 0;
     }
 
 
-    int port = ntohs(socket->sockaddr.sin_port);
-
-    return port;
+    return ntohs(socket->sockaddr.sin_port);
 
 }
 

--- a/src/ape_socket.c
+++ b/src/ape_socket.c
@@ -906,6 +906,19 @@ int APE_socket_write(ape_socket *socket, void *data, size_t len,
     return 0;
 }
 
+int APE_socket_port(ape_socket *socket)
+{
+    if (!socket) {
+        return -1;
+    }
+
+
+    int port = ntohs(socket->sockaddr.sin_port);
+
+    return port;
+
+}
+
 char *APE_socket_ipv4(ape_socket *socket)
 {
     if (!socket) {

--- a/src/ape_socket.h
+++ b/src/ape_socket.h
@@ -257,7 +257,7 @@ int APE_socket_writev(ape_socket *socket, const struct iovec *iov, int iovcnt);
 int APE_sendfile(ape_socket *socket, const char *file);
 int APE_socket_is_online(ape_socket *socket);
 
-int APE_socket_port(ape_socket *socket);
+uint16_t APE_socket_port(ape_socket *socket);
 char *APE_socket_ipv4(ape_socket *socket);
 
 int ape_socket_destroy(ape_socket *socket);

--- a/src/ape_socket.h
+++ b/src/ape_socket.h
@@ -257,6 +257,7 @@ int APE_socket_writev(ape_socket *socket, const struct iovec *iov, int iovcnt);
 int APE_sendfile(ape_socket *socket, const char *file);
 int APE_socket_is_online(ape_socket *socket);
 
+int APE_socket_port(ape_socket *socket);
 char *APE_socket_ipv4(ape_socket *socket);
 
 int ape_socket_destroy(ape_socket *socket);

--- a/tests/unittest_socket.cpp
+++ b/tests/unittest_socket.cpp
@@ -23,6 +23,7 @@
 //@TODO: void APE_socket_shutdown(ape_socket *socket);
 //@TODO: void APE_socket_shutdown_now(ape_socket *socket);
 //@TODO: int APE_sendfile(ape_socket *socket, const char *file);
+//@TODO: int APE_socket_port(ape_socket *socket);
 //@TODO: char *APE_socket_ipv4(ape_socket *socket);
 //@TODO: int APE_socket_is_online(ape_socket *socket)
 //@TODO: int ape_socket_do_jobs(ape_socket *socket);


### PR DESCRIPTION
This allows the nidium runtime to gather the socket's network port. It simply returns the port as int of the already existing sock struct.

No tests were found in tests/unittest_socket.cpp, so I added a TODO entry for it.
